### PR TITLE
add ability override field to allow manual base score adjustment

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1,5 +1,6 @@
 export const FALLOUTZERO = {
   systemId: 'falloutzero',
+  OVERRIDE_UNSET: -999,
 }
 
 /**
@@ -45,6 +46,7 @@ FALLOUTZERO.abilities = {
     reference: '',
     modifiers: 0,
     base: 0,
+    override: FALLOUTZERO.OVERRIDE_UNSET,
     penalties: true,
   },
   per: {
@@ -53,6 +55,7 @@ FALLOUTZERO.abilities = {
     reference: '',
     modifiers: 0,
     base: 0,
+    override: FALLOUTZERO.OVERRIDE_UNSET,
     penalties: true,
   },
   end: {
@@ -61,6 +64,7 @@ FALLOUTZERO.abilities = {
     reference: '',
     modifiers: 0,
     base: 0,
+    override: FALLOUTZERO.OVERRIDE_UNSET,
     penalties: true,
   },
   cha: {
@@ -69,6 +73,7 @@ FALLOUTZERO.abilities = {
     reference: '',
     modifiers: 0,
     base: 0,
+    override: FALLOUTZERO.OVERRIDE_UNSET,
     penalties: true,
   },
   int: {
@@ -77,6 +82,7 @@ FALLOUTZERO.abilities = {
     reference: '',
     modifiers: 0,
     base: 0,
+    override: FALLOUTZERO.OVERRIDE_UNSET,
     penalties: true,
   },
   agi: {
@@ -85,6 +91,7 @@ FALLOUTZERO.abilities = {
     reference: '',
     modifiers: 0,
     base: 0,
+    override: FALLOUTZERO.OVERRIDE_UNSET,
     penalties: true,
   },
   lck: {
@@ -93,6 +100,7 @@ FALLOUTZERO.abilities = {
     reference: '',
     modifiers: 0,
     base: 0,
+    override: FALLOUTZERO.OVERRIDE_UNSET,
     penalties: false,
   },
 }

--- a/module/data/actorBase.mjs
+++ b/module/data/actorBase.mjs
@@ -146,6 +146,10 @@ export default class FalloutZeroActor extends foundry.abstract.TypeDataModel {
           penalties: new fields.BooleanField({
             initial: FALLOUTZERO.abilities[ability].penalties,
           }),
+          override: new fields.NumberField({
+            ...requiredInteger,
+            initial: FALLOUTZERO.OVERRIDE_UNSET,
+          }),
           abbr: new fields.StringField({
             initial: FALLOUTZERO.abilities[ability].id,
           }),

--- a/module/data/character.mjs
+++ b/module/data/character.mjs
@@ -179,8 +179,9 @@ export default class FalloutZeroCharacter extends FalloutZeroActor {
     // Loop through ability scores, and add their modifiers to our sheet output.
     for (const key in this.abilities) {
       // Calculate the modifier using d20 rules.
-      if (this.abilities[key].base == 0) { this.abilities[key].base = this.abilities[key].value }
-      this.abilities[key].value = this.abilities[key].base + this.abilities[key].modifiers
+      const override = this.abilities[key].override
+      const effectiveBase = (override == FALLOUTZERO.OVERRIDE_UNSET) ? this.abilities[key].base : override
+      this.abilities[key].value = effectiveBase + this.abilities[key].modifiers
       this.abilities[key].mod = Math.floor(this.abilities[key].value - 5)
     }
     // Loop through skill scores, and add their modifiers to our sheet output.

--- a/module/data/npc.mjs
+++ b/module/data/npc.mjs
@@ -142,8 +142,9 @@ export default class FalloutZeroCharacter extends FalloutZeroActor {
     // Loop through ability scores, and add their modifiers to our sheet output.
     for (const key in this.abilities) {
       // Calculate the modifier using d20 rules.
-      if (this.abilities[key].base == 0) { this.abilities[key].base = this.abilities[key].value }
-      this.abilities[key].value = this.abilities[key].base + this.abilities[key].modifiers
+      const override = this.abilities[key].override
+      const effectiveBase = (override == FALLOUTZERO.OVERRIDE_UNSET) ? this.abilities[key].base : override
+      this.abilities[key].value = effectiveBase + this.abilities[key].modifiers
       this.abilities[key].mod = Math.floor(this.abilities[key].value - 5)
     }
     // Loop through skill scores, and add their modifiers to our sheet output.


### PR DESCRIPTION
- when adjusting special stats, you can use the overide attribute to override the base without running into issues such as the value not properly returning to its original value before modification
- a more advanced modification system is possible but this small modfication works fine for stuff like power armor active effects